### PR TITLE
Add filename length check on touch command

### DIFF
--- a/src/app/desktop/windows/terminal/terminal-states.ts
+++ b/src/app/desktop/windows/terminal/terminal-states.ts
@@ -209,6 +209,11 @@ export class DefaultTerminalState extends CommandTerminalState {
         content = args.slice(1).join(' ');
       }
 
+      if(filename.length > 64) {
+        this.terminal.outputText('That filename is too long');
+        return;
+      }
+
       this.websocket.ms('device', ['file', 'create'], {
         device_uuid: this.activeDevice['uuid'],
         filename: filename,


### PR DESCRIPTION
## Description
Added a check of the filename length when a new file is created

## Related Issue
#90 

## Motivation and Context
Currently `That file already exits` is printed when a filename is too long

## Type of change

- [X] Bug fix
- [ ] Feature request
- [ ] Documenting code

## Checklists

- [X] I referenced the according Issue
  - [ ] I created an Issue
  - [X] I put a link in the Section [Related Issue](#related-issue)
- [X] I tested my code with multiple browsers
- [X] I followed the [Angular style guide](https://angular.io/guide/styleguide)
- [X] My commit messages are good and understandable
