### PR TITLE
added maxlength check for username in sign-up

### DIFF
--- a/src/app/account/sign-up/sign-up.component.html
+++ b/src/app/account/sign-up/sign-up.component.html
@@ -34,7 +34,7 @@
     </form>
 
     <p *ngIf="error" class="error">{{error}}</p>
-    <p>The username must have at least 4 characters.</p>
+    <p>The username must have between 4 and 256 characters.</p>
     <p>Your password has to be at least 8 characters long, it must contain at least one uppercase letter, one lowercase
       letter and one number.</p>
     <p>If you have already created an account, then click <a [routerLink]="['/login']">here</a>.</p>

--- a/src/app/account/sign-up/sign-up.component.ts
+++ b/src/app/account/sign-up/sign-up.component.ts
@@ -19,7 +19,7 @@ export class SignUpComponent {
     private accountService: AccountService) {
 
     this.form = this.formBuilder.group({
-      username: ['', [Validators.required, Validators.minLength(4)]],
+      username: ['', [Validators.required, Validators.minLength(4), Validators.maxLength(256)]],
       password: ['', [
         Validators.required,
         Validators.minLength(8),


### PR DESCRIPTION
**Description**
The length of the username is now checked by a validator. That's why the response of the server don't have to get checked

**Issue**
Closes #146 

**Testing Instructions**
Try to sign-up with a username longer than 256 letters. It won't work anymore

**Additional Notes**
Also updated the requirement description rendered to the user.
Should the unfulfilled conditions marked with a color?
