### PR TITLE
Added a setting to change the account password

### DIFF
--- a/src/app/account/account.service.ts
+++ b/src/app/account/account.service.ts
@@ -6,6 +6,7 @@ import { SignUpResponse } from './interfaces/sign-up-response';
 import { Router, RouteReuseStrategy } from '@angular/router';
 import { WindowManagerService } from '../desktop/window-manager/window-manager.service';
 import { AppRouteReuseStrategy } from '../app-route-reuse-strategy';
+import { flatMap } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root'
@@ -32,6 +33,15 @@ export class AccountService {
     this.websocket.refreshAccountInfo().subscribe(() => {
       this.router.navigateByUrl(redirect).then();
     });
+  }
+
+  changePassword(oldPassword: string, newPassword: string) {
+    return this.websocket.request({ action: 'password', password: oldPassword, new: newPassword }).pipe(
+      flatMap(({ token }) => {
+        localStorage.setItem('token', token);
+        return this.websocket.refreshAccountInfo();
+      })
+    );
   }
 
   checkPassword(password: string): number {

--- a/src/app/account/sign-up/sign-up.component.ts
+++ b/src/app/account/sign-up/sign-up.component.ts
@@ -25,6 +25,7 @@ export class SignUpComponent {
       password: [history.state?.password ?? '', [
         Validators.required,
         Validators.minLength(8),
+        Validators.maxLength(64),
         Validators.pattern(/[0-9]/),
         Validators.pattern(/[A-Z]/),
         Validators.pattern(/[a-z]/)]

--- a/src/app/control-center/control-center-settings-page/control-center-settings-page.component.html
+++ b/src/app/control-center/control-center-settings-page/control-center-settings-page.component.html
@@ -1,1 +1,30 @@
-<h1>Settings page coming soon!</h1>
+<h1>Account Settings</h1>
+<p>Name: <span>{{apiService.account.name}}</span></p>
+<p>UUID: <span>{{apiService.account.uuid}}</span></p>
+<h2>Change password</h2>
+<form [formGroup]="passwordForm" (ngSubmit)="changePassword()" class="password-form">
+  <label>
+    Old password:
+    <input type="password" formControlName="oldPassword" autocomplete="password" placeholder="Password">
+  </label>
+  <label>
+    New password:
+    <input type="password" formControlName="newPassword" autocomplete="new-password" placeholder="Password">
+  </label>
+  <div class="strength">
+    <div [class.red-box]="passwordStrength >= 1"></div>
+    <div [class.red-box]="passwordStrength >= 2"></div>
+    <div [class.yellow-box]="passwordStrength >= 3"></div>
+    <div [class.green-box]="passwordStrength >= 4"></div>
+    <div [class.green-box]="passwordStrength >= 5"></div>
+  </div>
+  <label>
+    Confirm password:
+    <input type="password" formControlName="passwordConfirm" autocomplete="new-password" placeholder="Password">
+  </label>
+  <input type="submit" value="Submit" [disabled]="passwordForm.invalid">
+  <p>Your password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter
+    and one number.</p>
+  <p [hidden]="!passwordError" class="error">{{passwordError}}</p>
+  <p [hidden]="!passwordChanged">Password successfully changed.</p>
+</form>

--- a/src/app/control-center/control-center-settings-page/control-center-settings-page.component.scss
+++ b/src/app/control-center/control-center-settings-page/control-center-settings-page.component.scss
@@ -1,3 +1,81 @@
+@import "../control-center-style";
+@import "variables";
+
 h1 {
   margin-top: 0;
+}
+
+.password-form {
+  width: 45ch;
+
+  label {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 15px;
+  }
+
+  input[type=password] {
+    width: 50%;
+    margin-left: 5px;
+    outline: none;
+    border: 2px solid gray;
+    border-radius: 5px;
+    padding: 5px;
+  }
+
+  input[type=submit] {
+    padding: 12px;
+    color: white;
+    outline: none;
+    background-color: $sidebar-background;
+    border: 2px solid $button-border-color;
+    border-radius: 5px;
+
+    cursor: pointer;
+
+    &:hover {
+      background-color: $button-hover-color;
+    }
+  }
+
+  input[disabled] {
+    cursor: default;
+
+    &:hover {
+      background-color: $sidebar-background;
+    }
+  }
+
+  .strength {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    margin-bottom: 15px;
+
+    div {
+      width: 16.66%;
+      height: 6px;
+      background-color: #838789;
+      border-radius: 10px;
+      transition: background-color 200ms ease-in-out;
+
+      &.red-box {
+        background-color: red;
+      }
+
+      &.yellow-box {
+        background-color: yellow;
+      }
+
+      &.green-box {
+        background-color: green;
+      }
+    }
+  }
+
+  .error {
+    color: red;
+  }
 }

--- a/src/app/control-center/control-center-settings-page/control-center-settings-page.component.spec.ts
+++ b/src/app/control-center/control-center-settings-page/control-center-settings-page.component.spec.ts
@@ -1,6 +1,11 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ControlCenterSettingsPageComponent } from './control-center-settings-page.component';
+import { ReactiveFormsModule } from '@angular/forms';
+import { WebSocketSubject } from 'rxjs/internal-compatibility';
+import { webSocketMock } from '../../test-utils';
+import { RouterTestingModule } from '@angular/router/testing';
+import { RouteReuseStrategy } from '@angular/router';
 
 describe('ControlCenterSettingsPageComponent', () => {
   let component: ControlCenterSettingsPageComponent;
@@ -8,7 +13,12 @@ describe('ControlCenterSettingsPageComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ControlCenterSettingsPageComponent]
+      declarations: [ControlCenterSettingsPageComponent],
+      providers: [
+        { provide: WebSocketSubject, useValue: webSocketMock() },
+        { provide: RouteReuseStrategy, useValue: {} }
+      ],
+      imports: [ReactiveFormsModule, RouterTestingModule]
     })
       .compileComponents();
   }));

--- a/src/app/control-center/control-center-settings-page/control-center-settings-page.component.ts
+++ b/src/app/control-center/control-center-settings-page/control-center-settings-page.component.ts
@@ -21,6 +21,7 @@ export class ControlCenterSettingsPageComponent implements OnInit {
       newPassword: ['', [
         Validators.required,
         Validators.minLength(8),
+        Validators.maxLength(64),
         Validators.pattern(/[0-9]/),
         Validators.pattern(/[A-Z]/),
         Validators.pattern(/[a-z]/)

--- a/src/app/control-center/control-center-settings-page/control-center-settings-page.component.ts
+++ b/src/app/control-center/control-center-settings-page/control-center-settings-page.component.ts
@@ -1,4 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+import { WebsocketService } from '../../websocket.service';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { AccountService } from '../../account/account.service';
 
 @Component({
   selector: 'app-control-center-settings-page',
@@ -7,10 +10,56 @@ import { Component, OnInit } from '@angular/core';
 })
 export class ControlCenterSettingsPageComponent implements OnInit {
 
-  constructor() {
+  passwordForm: FormGroup;
+  passwordError: string;
+  passwordStrength = 0;
+  passwordChanged = false;
+
+  constructor(public apiService: WebsocketService, private formBuilder: FormBuilder, private accountService: AccountService) {
+    this.passwordForm = this.formBuilder.group({
+      oldPassword: ['', Validators.required],
+      newPassword: ['', [
+        Validators.required,
+        Validators.minLength(8),
+        Validators.pattern(/[0-9]/),
+        Validators.pattern(/[A-Z]/),
+        Validators.pattern(/[a-z]/)
+      ]],
+      passwordConfirm: ['', Validators.required]
+    });
+
+    this.passwordForm.valueChanges.subscribe(data => this.passwordStrength = this.accountService.checkPassword(data.newPassword));
   }
 
   ngOnInit(): void {
+  }
+
+  changePassword() {
+    if (this.passwordForm.valid) {
+      const { newPassword, passwordConfirm } = this.passwordForm.value;
+      if (newPassword !== passwordConfirm) {
+        this.passwordError = 'The passwords do not match.';
+        this.passwordChanged = false;
+        return;
+      }
+
+      this.accountService.changePassword(
+        this.passwordForm.value.oldPassword, this.passwordForm.value.newPassword
+      ).subscribe(() => {
+        this.passwordError = '';
+        this.passwordChanged = true;
+        this.passwordStrength = 0;
+        this.passwordForm.reset({ newPassword: '', oldPassword: '', passwordConfirm: '' });
+      }, error => {
+        this.passwordChanged = false;
+        if (error.message === 'permissions denied') {
+          this.passwordError = 'The old password is not correct.';
+        } else {
+          this.passwordError = error.message;
+          console.warn(error);
+        }
+      });
+    }
   }
 
 }


### PR DESCRIPTION
**Description**
The settings page in the control center now has an option that allows users to change their password.

**Issue**
Closes #202 

**Testing Instructions**
- Create a new account or log in to an existing one
- Navigate to the settings page in the control center
- Try changing the password with an incorrect old password
- Change the password using the correct previous password

