### PR TITLE
Added environment variable for the API URL and updated nginx config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+coverage
+dist
+local
+.git
+.github
+.vscode
+.idea
+.gitignore
+.editorconfig
+.travis.yml
+docker-compose.yml
+README.md
+STYLE.MD

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ trim_trailing_whitespace = true
 [*.md]
 max_line_length = off
 trim_trailing_whitespace = false
+
+[*.conf]
+indent_size = 4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:12-alpine as builder
 
-MAINTAINER faq@cryptic-game.net
-
 COPY package*.json ./
 
 RUN npm set progress=false && npm config set depth 0 && npm cache clean --force
@@ -17,6 +15,8 @@ RUN $(npm bin)/ng build --prod --build-optimizer
 
 FROM nginx:stable-alpine
 
+LABEL maintainer="faq@cryptic-game.net"
+
 EXPOSE 80
 
 COPY nginx/nginx.conf /etc/nginx/
@@ -26,5 +26,9 @@ RUN rm -rf /usr/share/nginx/html/*
 
 COPY --from=builder /ng-app/dist/frontend/ /usr/share/nginx/html
 RUN chown -R nginx:nginx /usr/share/nginx/html/
+
+COPY docker-write-api-file.sh /docker-entrypoint.d/
+
+RUN chmod +x /docker-entrypoint.d/docker-write-api-file.sh && apk add jq
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker-write-api-file.sh
+++ b/docker-write-api-file.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+if [ -n "$API_URL" ]; then
+  jq -cn --arg api_url "$API_URL" '{url: $api_url}' > /usr/share/nginx/html/assets/api.json
+fi

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,30 +1,26 @@
-
-
-
 server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
 
-  listen 80;
+    gzip on;
+    gzip_http_version 1.1;
+    gzip_disable      "MSIE [1-6]\.";
+    gzip_min_length   256;
+    gzip_vary         on;
+    gzip_proxied      expired no-cache no-store private auth;
+    gzip_types        text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+    gzip_comp_level   4;
 
-  sendfile on;
+    root /usr/share/nginx/html;
 
-  default_type application/octet-stream;
+    location = /ngsw.json {
+        # NGSW fail-safe if file removed
+    }
 
+    location = /ngsw-worker.js {
+    }
 
-  gzip on;
-  gzip_http_version 1.1;
-  gzip_disable      "MSIE [1-6]\.";
-  gzip_min_length   256;
-  gzip_vary         on;
-  gzip_proxied      expired no-cache no-store private auth;
-  gzip_types        text/plain text/css application/json application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript;
-  gzip_comp_level   9;
-
-
-  root /usr/share/nginx/html;
-
-
-  location / {
-    try_files $uri $uri/ /index.html;
-  }
-
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -25,19 +25,5 @@ http {
 
     keepalive_timeout  65;
 
-    #gzip  on;
-
-
-    server {
-        listen 80 default_server;
-        listen [::]:80 default_server;
- 
-        root /usr/share/nginx/html;
-        index index.html index.htm index.nginx-debian.html;
- 
-        location / {
-                try_files $uri $uri/ /index.html;
-        }
-    }     
     include /etc/nginx/conf.d/*.conf;
 }

--- a/ngsw-config.json
+++ b/ngsw-config.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "assets",
-      "installMode": "lazy",
+      "installMode": "prefetch",
       "resources": {
         "files": [
           "/assets/**",
@@ -37,9 +37,10 @@
         "/api.json"
       ],
       "cacheConfig": {
-        "strategy": "performance",
+        "strategy": "freshness",
         "maxSize": 5,
-        "maxAge": "3d"
+        "maxAge": "5d",
+        "timeout": "60u"
       }
     },
     {


### PR DESCRIPTION
**Description**
Added the ability to set the URL of the WebSocket backend more conveniently using the environment variable `API_URL` in Docker.
In addition, I updated the nginx configuration. There were two server blocks, one of which was ignored. Gzip compression is also activated now.

**Issue**
Previously, the URL had to be mounted into the container in an api.json file, which is not very convenient.

**Testing Instructions**
- Run a Docker container with an `API_URL` variable set.
- Open the website in a browser that supports compression and check a file response that is longer than 255 bytes.
