### PR TITLE
Issue/39 autocomplete

### DIFF
--- a/src/app/desktop/windows/terminal/terminal-states.ts
+++ b/src/app/desktop/windows/terminal/terminal-states.ts
@@ -53,10 +53,7 @@ export abstract class CommandTerminalState implements TerminalState {
 
   autocomplete(content: string): string {
     return content
-      ? this.getHistory()
-        .reverse()
-        .find(n => n.startsWith(content)) ||
-        Object.entries(this.commands)
+      ? Object.entries(this.commands)
         .filter(command => !('hidden' in command[1]))
         .map(([name]) => name)
         .sort()

--- a/src/app/desktop/windows/terminal/terminal-states.ts
+++ b/src/app/desktop/windows/terminal/terminal-states.ts
@@ -54,7 +54,7 @@ export abstract class CommandTerminalState implements TerminalState {
   autocomplete(content: string): string {
     return content
       ? Object.entries(this.commands)
-        .filter(command => !('hidden' in command[1]))
+        .filter(command => !command[1].hidden)
         .map(([name]) => name)
         .sort()
         .find(n => n.startsWith(content))

--- a/src/app/desktop/windows/terminal/terminal-states.ts
+++ b/src/app/desktop/windows/terminal/terminal-states.ts
@@ -53,9 +53,12 @@ export abstract class CommandTerminalState implements TerminalState {
 
   autocomplete(content: string): string {
     return content
-      ? Object.entries(this.commands)
+      ? this.getHistory()
+        .reverse()
+        .find(n => n.startsWith(content)) ||
+        Object.entries(this.commands)
         .filter(command => !('hidden' in command[1]))
-        .map(([name, _value]) => name)
+        .map(([name]) => name)
         .sort()
         .find(n => n.startsWith(content))
       : '';

--- a/src/app/desktop/windows/terminal/terminal-states.ts
+++ b/src/app/desktop/windows/terminal/terminal-states.ts
@@ -25,7 +25,7 @@ function reportError(error) {
 }
 
 export abstract class CommandTerminalState implements TerminalState {
-  abstract commands: { [name: string]: { executor: (args: string[]) => void, description: string } };
+  abstract commands: { [name: string]: { executor: (args: string[]) => void, description: string, hidden?: boolean } };
 
   protocol: string[] = [];
 
@@ -53,8 +53,9 @@ export abstract class CommandTerminalState implements TerminalState {
 
   autocomplete(content: string): string {
     return content
-      ? Object.keys(this.commands)
-        .filter(n => !['chaozz'].includes(n))
+      ? Object.entries(this.commands)
+        .filter(command => !('hidden' in command[1]))
+        .map(([name, _value]) => name)
         .sort()
         .find(n => n.startsWith(content))
       : '';
@@ -78,7 +79,7 @@ export class DefaultTerminalState extends CommandTerminalState {
     },
     'status': {
       executor: this.status.bind(this),
-      description: 'displays the number of online plyers'
+      description: 'displays the number of online players'
     },
     'hostname': {
       executor: this.hostname.bind(this),
@@ -176,7 +177,8 @@ export class DefaultTerminalState extends CommandTerminalState {
     // easter egg
     'chaozz': {
       executor: () => this.terminal.outputText('"mess with the best, die like the rest :D`" - chaozz'),
-      description: ''
+      description: '',
+      hidden: true
     }
   };
 
@@ -241,8 +243,8 @@ export class DefaultTerminalState extends CommandTerminalState {
   help() {
     const table = document.createElement('table');
     Object.entries(this.commands)
+      .filter(command => !('hidden' in command[1]))
       .map(([name, value]) => ({ name: name, description: value.description }))
-      .filter(command => !['chaozz'].includes(command.name))
       .map(command => `<tr><td>${command.name}</td><td>${command.description}</td></tr>`)
       .forEach(row => {
         table.innerHTML += row;


### PR DESCRIPTION
# Rebase of #172 

**Description**
The autocompletion searches also in the history. Also changed how commands are hidden (attribute instead of excluding by name).

**Issue**
#39 (probably don't close it -> Addititional Notes)

**Testing Instructions**
- write something in the terminal
- write the beginning again and press [Tab]

**Additional Notes**
- fixed typo
- Should there also a hint about what will be completed? (like in fish)