### PR TITLE
Fixed Bruteforce Bug #224

### DIFF
--- a/src/app/desktop/windows/terminal/terminal-states.ts
+++ b/src/app/desktop/windows/terminal/terminal-states.ts
@@ -1061,7 +1061,7 @@ export class DefaultTerminalState extends CommandTerminalState {
             }
           }, (err) => {
               if (err.message === 'service_not_running') {
-                this.terminal.outputText('This Computer or Service is not Online.');
+                this.terminal.outputText('Target service is unreachable.');
               }
           });
         }, error => {

--- a/src/app/desktop/windows/terminal/terminal-states.ts
+++ b/src/app/desktop/windows/terminal/terminal-states.ts
@@ -1059,6 +1059,10 @@ export class DefaultTerminalState extends CommandTerminalState {
             if (differentServiceAttacked) {
               startAttack();
             }
+          }, (err) => {
+              if (err.message === 'service_not_running') {
+                this.terminal.outputText('This Computer or Service is not Online.');
+              }
           });
         }, error => {
           if (error.message === 'attack_not_running') {


### PR DESCRIPTION
**Description**
Shows an "Error" in the Terminal when you type stop an the Target Device/Service is not Online.
**Issue**
Closes #224 

**Testing Instructions**
- Start 2 Computers
- Start bruteforcing Computer 2
- Shutdown Computer 2
- Type in stop to the Bruteforce Interface
- You should see the "Error"
