### PR TITLE
Added error handling for too long wallet names (#213)

### DIFF
--- a/src/app/desktop/windows/terminal/terminal-states.ts
+++ b/src/app/desktop/windows/terminal/terminal-states.ts
@@ -832,6 +832,7 @@ export class DefaultTerminalState extends CommandTerminalState {
             this.terminal.outputText('That file already exists');
           }, error => {
             if (error.message === 'file_not_found') {
+              if (path.path[path.path.length - 1].length < 65) {
               this.websocket.ms('currency', ['create'], {}).subscribe(wallet => {
                 const credentials = wallet.source_uuid + ' ' + wallet.key;
 
@@ -851,6 +852,9 @@ export class DefaultTerminalState extends CommandTerminalState {
                   reportError(error1);
                 }
               });
+              } else {
+                this.terminal.outputText('Filename too long. Only 64 chars allowed');
+              }
             } else {
               reportError(error);
             }


### PR DESCRIPTION
**Description**
Prevents the creation of an wallet in the terminal, when the given name is longer than allowed for an file

**Issue**
Closes #213

**Testing Instructions**
Open the terminal an type 'morphcoin create NAME' with name having more than 64 characters
desired result: no wallet creation and error message on terminal
