### PR TITLE
 Clear the terminal history on command (#305 )

### DIFF
--- a/src/app/desktop/windows/terminal/terminal-states.ts
+++ b/src/app/desktop/windows/terminal/terminal-states.ts
@@ -150,6 +150,10 @@ export class DefaultTerminalState extends CommandTerminalState {
       executor: this.history.bind(this),
       description: 'shows the command history of the current terminal session'
     },
+    'clearhistory': {
+      executor: this.historyClear.bind(this),
+      description: 'clears the history of used commands in this terminal session'
+    },
     'morphcoin': {
       executor: this.morphcoin.bind(this),
       description: 'shows wallet'
@@ -771,6 +775,10 @@ export class DefaultTerminalState extends CommandTerminalState {
     l.forEach(e => {
       this.terminal.outputText(e);
     });
+  }
+
+  historyClear() {
+    this.protocol = [];
   }
 
   morphcoin(args: string[]) {

--- a/src/app/desktop/windows/terminal/terminal.component.spec.ts
+++ b/src/app/desktop/windows/terminal/terminal.component.spec.ts
@@ -31,4 +31,21 @@ describe('TerminalComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should add commands to the protocol', () => {
+    component.execute('test');
+    component.execute('help');
+    component.execute('help');
+    expect(component.getHistory().length).toBe(2);
+    // History is printed in reverse
+    expect(component.getHistory()).toEqual(['help', 'help']);
+  });
+
+  it('should clear the protocol with clearHistory', () => {
+    component.execute('test');
+    component.execute('help');
+    component.execute('help');
+    component.execute('clearHistory');
+    expect(component.getHistory().length).toBe(0);
+  });
 });


### PR DESCRIPTION
**Description**
- Added the command to clear your command-history in the terminal 
- Only successful commands will be shown in protocol and commands can now be flagged for with "hideFromProtocol".
- Added two tests for the terminal protocol
**Issue**
Closes #305 