### PR TITLE
#323 also save wrong commands

### DIFF
--- a/src/app/desktop/window/window-frame.component.ts
+++ b/src/app/desktop/window/window-frame.component.ts
@@ -161,10 +161,21 @@ export class WindowFrameComponent implements OnInit {
           this.delegate.position.maximized = false;
         }
 
-        this.delegate.position.x = Math.min(Math.max(0, this.dragStartWindowPos[0] + event.clientX - this.dragStartPos[0]),
-          window.innerWidth - this.delegate.position.width / 2);
-        this.delegate.position.y = Math.min(Math.max(0, this.dragStartWindowPos[1] + event.clientY - this.dragStartPos[1]),
-          window.innerHeight - this.delegate.position.height / 2);
+        this.delegate.position.x =
+          Math.min(
+            Math.min(
+              Math.max(0, this.dragStartWindowPos[0] + event.clientX - this.dragStartPos[0]), // Don't drag out of left side.
+              window.innerWidth - this.delegate.position.width / 2),  // Don't drag further than size of window.
+            window.innerWidth - this.windowManager.activeWindow.position.width); // Don't drag further than right side
+
+        this.delegate.position.y =
+          Math.min(
+            Math.min(
+              Math.max(
+                0, this.dragStartWindowPos[1] + event.clientY - this.dragStartPos[1]), // Don't drag out of top side.
+              window.innerHeight - this.delegate.position.height / 2), // Don't drag further than size of window.
+            window.innerHeight - this.windowManager.activeWindow.position.height - 55); // Don't drag further than bottom side + taskbar.
+
       } else if (this.resizing) {
         /**
          * 7  4  8

--- a/src/app/desktop/window/window-frame.component.ts
+++ b/src/app/desktop/window/window-frame.component.ts
@@ -161,21 +161,10 @@ export class WindowFrameComponent implements OnInit {
           this.delegate.position.maximized = false;
         }
 
-        this.delegate.position.x =
-          Math.min(
-            Math.min(
-              Math.max(0, this.dragStartWindowPos[0] + event.clientX - this.dragStartPos[0]), // Don't drag out of left side.
-              window.innerWidth - this.delegate.position.width / 2),  // Don't drag further than size of window.
-            window.innerWidth - this.windowManager.activeWindow.position.width); // Don't drag further than right side
-
-        this.delegate.position.y =
-          Math.min(
-            Math.min(
-              Math.max(
-                0, this.dragStartWindowPos[1] + event.clientY - this.dragStartPos[1]), // Don't drag out of top side.
-              window.innerHeight - this.delegate.position.height / 2), // Don't drag further than size of window.
-            window.innerHeight - this.windowManager.activeWindow.position.height - 55); // Don't drag further than bottom side + taskbar.
-
+        this.delegate.position.x = Math.min(Math.max(0, this.dragStartWindowPos[0] + event.clientX - this.dragStartPos[0]),
+          window.innerWidth - this.delegate.position.width / 2);
+        this.delegate.position.y = Math.min(Math.max(0, this.dragStartWindowPos[1] + event.clientY - this.dragStartPos[1]),
+          window.innerHeight - this.delegate.position.height / 2);
       } else if (this.resizing) {
         /**
          * 7  4  8

--- a/src/app/desktop/windows/terminal/terminal-states.ts
+++ b/src/app/desktop/windows/terminal/terminal-states.ts
@@ -38,7 +38,9 @@ export abstract class CommandTerminalState implements TerminalState {
   executeCommand(command: string, args: string[]) {
     command = command.toLowerCase();
     // Add command to protocol
-    this.protocol.unshift(command);
+    if (!this.commands[command].hideFromProtocol) {
+      this.protocol.unshift(command);
+    }
     if (this.commands.hasOwnProperty(command)) {
       this.commands[command].executor(args);
     } else if (command !== '') {

--- a/src/app/desktop/windows/terminal/terminal-states.ts
+++ b/src/app/desktop/windows/terminal/terminal-states.ts
@@ -37,13 +37,10 @@ export abstract class CommandTerminalState implements TerminalState {
 
   executeCommand(command: string, args: string[]) {
     command = command.toLowerCase();
+    // Add command to protocol
+    this.protocol.unshift(command);
     if (this.commands.hasOwnProperty(command)) {
       this.commands[command].executor(args);
-
-      // Only successful and not-flagged commands will be shown in the protocol.
-      if (!this.commands[command].hideFromProtocol) {
-        this.protocol.unshift(command);
-      }
     } else if (command !== '') {
       this.commandNotFound(command);
     }

--- a/src/app/desktop/windows/terminal/terminal.component.spec.ts
+++ b/src/app/desktop/windows/terminal/terminal.component.spec.ts
@@ -36,9 +36,9 @@ describe('TerminalComponent', () => {
     component.execute('test');
     component.execute('help');
     component.execute('help');
-    expect(component.getHistory().length).toBe(2);
+    expect(component.getHistory().length).toBe(3);
     // History is printed in reverse
-    expect(component.getHistory()).toEqual(['help', 'help']);
+    expect(component.getHistory()).toEqual(['help', 'help', 'test']);
   });
 
   it('should clear the protocol with clearHistory', () => {


### PR DESCRIPTION
**Description**
> Terminal commands are now stored in the history not after, but before the correctness check.

**Issue**
Closes #323 

**Testing Instructions**
> Type e.g. `help` (an existing command) into the terminal followed by a non-existing e.g. `test`. By pressing the up arrow, `test` should now appear in the terminal.

**Additional Notes**
> Reminder: UI/UX improvement due to imitation of a real terminal.
