### PR TITLE
Fix the history not remembering the arguments for commands

### DIFF
--- a/src/app/desktop/windows/terminal/terminal-states.ts
+++ b/src/app/desktop/windows/terminal/terminal-states.ts
@@ -47,7 +47,7 @@ export abstract class CommandTerminalState implements TerminalState {
       // Only successful and not-flagged commands will be shown in the protocol.
       if (!this.commands[command].hideFromProtocol) {
         if (args.length>0) {
-          this.protocol.unshift(command + " " + args.join(" "));
+          this.protocol.unshift(command + ' ' + args.join(' '));
         } else {
           this.protocol.unshift(command);
         }

--- a/src/app/desktop/windows/terminal/terminal-states.ts
+++ b/src/app/desktop/windows/terminal/terminal-states.ts
@@ -46,7 +46,11 @@ export abstract class CommandTerminalState implements TerminalState {
 
       // Only successful and not-flagged commands will be shown in the protocol.
       if (!this.commands[command].hideFromProtocol) {
-        this.protocol.unshift(command);
+        if (args.length>0) {
+          this.protocol.unshift(command + " " + args.join(" "));
+        } else {
+          this.protocol.unshift(command);
+        }
       }
     } else if (command !== '') {
       this.commandNotFound(command);

--- a/src/app/desktop/windows/terminal/terminal.component.spec.ts
+++ b/src/app/desktop/windows/terminal/terminal.component.spec.ts
@@ -35,10 +35,10 @@ describe('TerminalComponent', () => {
   it('should add commands to the protocol', () => {
     component.execute('test');
     component.execute('help');
-    component.execute('help');
+    component.execute('help help');
     expect(component.getHistory().length).toBe(2);
     // History is printed in reverse
-    expect(component.getHistory()).toEqual(['help', 'help']);
+    expect(component.getHistory()).toEqual(['help help', 'help']);
   });
 
   it('should clear the protocol with clearHistory', () => {


### PR DESCRIPTION
**Description**
Fix the history not remembering the arguments for commands

**Issue**
Closes #332 

**Testing Instructions**
1. Start a terminal
2. enter the command `help`
3. enter the command `help arg1 arg2`
4. enter the command `history`
5. You should see both `help` commands and the second one with its arguments.

**Additional Notes**
During the testing of this, i discovered that the `history` command reverses the terminal history every time it is invoked. I will be fixing this in an upcoming Pull Request.
