### PR TITLE
Ignore markdown and vscode folder for actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,13 @@ on:
   push:
     branches: [ master ]
     tags: [ 'v*' ]
+    paths-ignore:
+      - ".vscode/**"
+      - "*.md"
   pull_request:
+    paths-ignore:
+        - ".vscode/**"
+        - "*.md"
 
 env:
   GHCR_SLUG: ghcr.io/cryptic-game/frontend

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,10 @@ on:
         - ".vscode/**"
         - "*.md"
 
+concurrency:
+  group: ${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 env:
   GHCR_SLUG: ghcr.io/cryptic-game/frontend
   DOCKER_PLATFORMS: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x


### PR DESCRIPTION
This reduces the action runs and removes the unecessary wait time if parts of the project change which do not interfere with the code of the project.